### PR TITLE
Added tenantId support for Create methods

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/annotation/Create.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/annotation/Create.java
@@ -45,6 +45,11 @@ public @interface Create {
 	 */
 	// NB: Read, Search (maybe others) share this annotation, so update the javadocs everywhere
 	Class<? extends IBaseResource> type() default IBaseResource.class;
+
+	/**
+	 * If specified, this is the ID of the tenant that the search is for.
+	 */
+	String tenantId() default "";
 	
 
 }

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/CreateMethodBinding.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/CreateMethodBinding.java
@@ -26,6 +26,8 @@ import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.Set;
 
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IIdType;
 
@@ -40,8 +42,12 @@ import javax.annotation.Nonnull;
 
 public class CreateMethodBinding extends BaseOutcomeReturningMethodBindingWithResourceParam {
 
+	private final String myTenantId;
+
 	public CreateMethodBinding(Method theMethod, FhirContext theContext, Object theProvider) {
 		super(theMethod, theContext, Create.class, theProvider);
+		Create create = theMethod.getAnnotation(Create.class);
+		this.myTenantId = StringUtils.defaultIfBlank(create.tenantId(), null);
 	}
 
 	@Override
@@ -58,6 +64,15 @@ public class CreateMethodBinding extends BaseOutcomeReturningMethodBindingWithRe
 	@Override
 	protected Set<RequestTypeEnum> provideAllowableRequestTypes() {
 		return Collections.singleton(RequestTypeEnum.POST);
+	}
+
+	@Override
+	public MethodMatchEnum incomingServerRequestMatchesMethod(RequestDetails theRequest) {
+		if (!StringUtils.equals(myTenantId, theRequest.getTenantId())) {
+			ourLog.trace("Method {} doesn't match because it is for tenant {} but request is for tenant {}", getMethod(), myTenantId, theRequest.getTenantId());
+			return MethodMatchEnum.NONE;
+		}
+		return super.incomingServerRequestMatchesMethod(theRequest);
 	}
 
 	@Override


### PR DESCRIPTION
This PR adds support for tenantIds just like it is currently done for Operation and Read methods.

* Added a tenantId field to the Create annotation
* Added method override to check the tenantId when matching method.

# Testing the Pull Request
I'm not really sure how to test this properly. Best bet is to just add it to the hinq-fhir-server and try to POST something to a particular tenant.

# Pull Request Reviewing

To review this pull request, please utilize the checklist below that is based on our [pull request review guidelines](https://www.notion.so/ivido/Pull-Request-Reviewing-b89fa374e2704319a0249d729db65eee).

- [ ] Does the pull request adhere to the [functionality requirements and guidelines](https://www.notion.so/ivido/Pull-Request-Reviewing-b89fa374e2704319a0249d729db65eee#b8e3e91cecc7439f8148db51c57b4d91)?
- [ ] Does the pull request adhere to [code quality guidelines](https://www.notion.so/ivido/Pull-Request-Reviewing-b89fa374e2704319a0249d729db65eee#764284756c264f1684bc7a9d49d054df)?
- [ ] Are [optimizations possible](https://www.notion.so/ivido/Pull-Request-Reviewing-b89fa374e2704319a0249d729db65eee#bc27253ddf1b412fbdc7c2aca818bf17) for the content in this pull request?
- [ ] Is the content in the pull request [properly tested and validated](https://www.notion.so/ivido/Pull-Request-Reviewing-b89fa374e2704319a0249d729db65eee#df8d441dae0044cb9414d2cf4a929a10)?
- [ ] Is the pull request [properly documented](https://www.notion.so/ivido/Pull-Request-Reviewing-b89fa374e2704319a0249d729db65eee#131d60cb910040c9a482c84210478e8c), both [in the code](https://www.notion.so/ivido/Pull-Request-Reviewing-b89fa374e2704319a0249d729db65eee#8a3533ffc8d14ecf91bb8c128ba35074) and in [documentation](https://www.notion.so/ivido/Pull-Request-Reviewing-b89fa374e2704319a0249d729db65eee#5c6f8baa61cb4111981ef02d828da335)?
- [ ] Do the changes in the codebase [break existing functionality or endpoints](https://www.notion.so/ivido/Pull-Request-Reviewing-b89fa374e2704319a0249d729db65eee#dbc4674b18b84fdcb2692e22c16e69ce) that may be relevant to partners?
- [ ] Are our partners informed of this change if necessary?
